### PR TITLE
Implement crosspost sharing with original community reference

### DIFF
--- a/client/src/components/PostCard.jsx
+++ b/client/src/components/PostCard.jsx
@@ -14,12 +14,14 @@ import { formatDistanceToNow } from 'date-fns';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import DeleteModal from './DeleteModal';
+import SharePostModal from './SharePostModal';
 import { Carousel } from 'react-bootstrap';
 
 export default function PostCard({ post, location = 'home' }) {
   const [isOwner, setIsOwner] = useState(false);
   const [showOptions, setShowOptions] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showShareModal, setShowShareModal] = useState(false);
   const dropdownRef = useRef(null);
   const navigate = useNavigate();
 
@@ -50,7 +52,7 @@ export default function PostCard({ post, location = 'home' }) {
         headers: { Authorization: `Bearer ${token}` },
       })
       .then(() => window.location.reload())
-      .catch(() => alert('❌ Delete failed'));
+      .catch(() => alert('Delete failed'));
   };
 
   const goToSinglePost = () => {
@@ -133,6 +135,13 @@ export default function PostCard({ post, location = 'home' }) {
         </p>
       </div>
 
+      {post.originalPostId && post.originalCommunity && (
+        <div className="text-muted" style={{ fontSize: '12px' }}>
+          Shared from <span className="text-info">c/{post.originalCommunity}</span>
+        </div>
+      )}
+
+
       {post.mediaUrls?.length === 1 && renderSingleMedia(post.mediaUrls[0])}
       {post.mediaUrls?.length > 1 && renderCarousel()}
 
@@ -146,11 +155,22 @@ export default function PostCard({ post, location = 'home' }) {
         >
           <FontAwesomeIcon icon={faCommentDots} className="me-1" /> 0
         </span>
-
-        <span><FontAwesomeIcon icon={faShare} className="me-1" /> Share</span>
+        <span role="button" onClick={() => setShowShareModal(true)}>
+          <FontAwesomeIcon icon={faShare} className="me-1" /> Share
+        </span>
       </div>
 
-      <DeleteModal show={showDeleteModal} onHide={() => setShowDeleteModal(false)} onConfirm={confirmDelete} />
+      <DeleteModal
+        show={showDeleteModal}
+        onHide={() => setShowDeleteModal(false)}
+        onConfirm={confirmDelete}
+      />
+
+      <SharePostModal
+        show={showShareModal}
+        onHide={() => setShowShareModal(false)}
+        originalPost={post}
+      />
     </div>
   );
 }

--- a/client/src/components/SharePostModal.jsx
+++ b/client/src/components/SharePostModal.jsx
@@ -1,0 +1,77 @@
+// client/src/components/SharePostModal.jsx
+// client/src/components/SharePostModal.jsx
+import React, { useState, useEffect } from 'react';
+import { Modal, Button, Form } from 'react-bootstrap';
+import axios from 'axios';
+import { toast } from 'react-toastify';
+
+export default function SharePostModal({ show, onHide, originalPost }) {
+  const [communities, setCommunities] = useState([]);
+  const [selectedCommunity, setSelectedCommunity] = useState('');
+  const token = localStorage.getItem('snappixSession');
+
+  useEffect(() => {
+    if (show && token) {
+      axios.get('http://localhost:8080/api/communities/joined', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then(res => setCommunities(res.data))
+        .catch(() => toast.error('Failed to fetch communities'));
+    }
+  }, [show, token]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await axios.post('http://localhost:8080/api/posts/crosspost', {
+        originalPostId: originalPost.id,
+        title: (originalPost.description || '').split('\n')[0],
+        community: selectedCommunity
+      }, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      toast.success('Post shared successfully!');
+      onHide();
+    } catch (err) {
+      toast.error('Failed to share post');
+    }
+  };
+
+  return (
+    <Modal show={show} onHide={onHide} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Share Post to Community</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form onSubmit={handleSubmit}>
+          <Form.Group className="mb-3">
+            <Form.Label>Choose community</Form.Label>
+            <Form.Select
+              value={selectedCommunity}
+              onChange={(e) => setSelectedCommunity(e.target.value)}
+              required
+            >
+              <option value="">-- Select --</option>
+              {communities.map((c) => (
+                <option key={c.id} value={c.name}>c/{c.name}</option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Label>Original Title</Form.Label>
+            <Form.Control
+              value={(originalPost.description || '').split('\n')[0]}
+              readOnly
+              disabled
+            />
+          </Form.Group>
+
+          <Button type="submit" className="mt-3 w-100" variant="warning">
+            Share
+          </Button>
+        </Form>
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/server/src/main/java/com/snappix/server/model/Post.java
+++ b/server/src/main/java/com/snappix/server/model/Post.java
@@ -20,6 +20,10 @@ public class Post {
     private List<String> mediaUrls;
     private Date createdAt = new Date();
 
+    // Crosspost fields
+    private String originalPostId;
+    private String originalCommunity;
+
     public Post() {}
 
     public Post(String userEmail, String userName, String community, String description, List<String> mediaUrls) {
@@ -28,25 +32,75 @@ public class Post {
         this.community = community;
         this.description = description;
         this.mediaUrls = mediaUrls;
+        this.createdAt = new Date();
     }
 
-    public String getId() { return id; }
+    // Getters & Setters
+    public String getId() {
+        return id;
+    }
 
-    public String getUserEmail() { return userEmail; }
-    public void setUserEmail(String userEmail) { this.userEmail = userEmail; }
+    public String getUserEmail() {
+        return userEmail;
+    }
 
-    public String getUserName() { return userName; }
-    public void setUserName(String userName) { this.userName = userName; }
+    public void setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
+    }
 
-    public String getCommunity() { return community; }
-    public void setCommunity(String community) { this.community = community; }
+    public String getUserName() {
+        return userName;
+    }
 
-    public String getDescription() { return description; }
-    public void setDescription(String description) { this.description = description; }
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
 
-    public List<String> getMediaUrls() { return mediaUrls; }
-    public void setMediaUrls(List<String> mediaUrls) { this.mediaUrls = mediaUrls; }
+    public String getCommunity() {
+        return community;
+    }
 
-    public Date getCreatedAt() { return createdAt; }
-    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+    public void setCommunity(String community) {
+        this.community = community;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<String> getMediaUrls() {
+        return mediaUrls;
+    }
+
+    public void setMediaUrls(List<String> mediaUrls) {
+        this.mediaUrls = mediaUrls;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getOriginalPostId() {
+        return originalPostId;
+    }
+
+    public void setOriginalPostId(String originalPostId) {
+        this.originalPostId = originalPostId;
+    }
+
+    public String getOriginalCommunity() {
+        return originalCommunity;
+    }
+
+    public void setOriginalCommunity(String originalCommunity) {
+        this.originalCommunity = originalCommunity;
+    }
 }

--- a/server/src/main/java/com/snappix/server/repository/PostRepository.java
+++ b/server/src/main/java/com/snappix/server/repository/PostRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 public interface PostRepository extends MongoRepository<Post, String> {
     List<Post> findByUserEmail(String email);
     List<Post> findByCommunityIgnoreCase(String community);
+    List<Post> findByOriginalPostIdAndUserEmail(String originalPostId, String email);
 
 }


### PR DESCRIPTION
- Updated Post model to include `originalCommunity` for crossposted posts
- Modified PostController to: • Save `originalCommunity` during crossposting • Remove redundant "(Shared from c/...)" text from post description
- Updated PostCard.jsx to display "Shared from c/{originalCommunity}" only once using a separate UI section
- Fixed SharePostModal to correctly POST crosspost metadata
- Cleaned up GET by ID method in PostController to prevent response formatting errors